### PR TITLE
docs/add-github-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,9 @@ To run this bot we recommend you a cloud instance with a minimum of:
 - [TA-Lib](https://ta-lib.github.io/ta-lib-python/)
 - [virtualenv](https://virtualenv.pypa.io/en/stable/installation.html) (Recommended)
 - [Docker](https://www.docker.com/products/docker) (Recommended)
+
+---
+
+## Source Code
+
+Check out the full source code on [GitHub](https://github.com/freqtrade/freqtrade)


### PR DESCRIPTION
This PR adds a link to the GitHub repository at the end of the README file.
It makes it easier for users to find the source code directly from the documentation.

